### PR TITLE
Fix build_android.sh script

### DIFF
--- a/lib/build-android.sh
+++ b/lib/build-android.sh
@@ -14,5 +14,6 @@ export AR=$TOOLCHAIN/bin/$TARGET-ar
 export AS=$TOOLCHAIN/bin/$TARGET-as
 
 cargo build --target $TARGET
+mkdir -p ../android/app/src/main/jniLibs/x86/
 cp ../target/$TARGET/debug/libfirma.so ../android/app/src/main/jniLibs/x86/
 


### PR DESCRIPTION
Create the the android/app/src/main/jniLibs/x86/ directory before copying files to it.